### PR TITLE
Fix end of stance bug

### DIFF
--- a/local_planner/src/local_footstep_planner.cpp
+++ b/local_planner/src/local_footstep_planner.cpp
@@ -178,7 +178,8 @@ void LocalFootstepPlanner::computeFootPlan(
         if (isContact(contact_schedule, end_of_stance, j)) {
           // Means we get to the end of horizon, so we should use the nominal
           // period
-          end_of_stance = i + period_ * duty_cycles_[j];
+          end_of_stance =
+              std::max(i + int(period_ * duty_cycles_[j]), end_of_stance);
 
           // Integrate the plan if out of the horizon
           body_plan_stance = Eigen::MatrixXd(end_of_stance + 1, 12);

--- a/local_planner/src/local_footstep_planner.cpp
+++ b/local_planner/src/local_footstep_planner.cpp
@@ -176,8 +176,8 @@ void LocalFootstepPlanner::computeFootPlan(
         // Compute the body plan including the stance phase
         Eigen::MatrixXd body_plan_stance;
         if (isContact(contact_schedule, end_of_stance, j)) {
-          // Means we get to the end of horizon, so we should use the nominal
-          // period
+          // Compute the index of the end of the stance phase using the nominal
+          // stance duration (make sure not smaller than horizon)
           end_of_stance =
               std::max(i + int(period_ * duty_cycles_[j]), end_of_stance);
 


### PR DESCRIPTION
End of stance needs to be at least as long as the horizon length, which could be violated right now if the current stance phase exceeds the nominal it throws malloc errors. This change fixes by ensuring end_of_stance it never decreased.