### PR TITLE
Add tcpnodelay hint to sim command topic

### DIFF
--- a/quad_simulator/gazebo_scripts/src/controller_plugin.cpp
+++ b/quad_simulator/gazebo_scripts/src/controller_plugin.cpp
@@ -89,7 +89,8 @@ bool SpiritController::init(hardware_interface::EffortJointInterface* hw,
                            joint_command_topic);
 
   sub_command_ = n.subscribe<quad_msgs::LegCommandArray>(
-      joint_command_topic, 1, &SpiritController::commandCB, this);
+      joint_command_topic, 1, &SpiritController::commandCB, this,
+      ros::TransportHints().tcpNoDelay());
   return true;
 }
 


### PR DESCRIPTION
This one got missed in the prior PR and should actually improve performance, not just debugging (should lead to joint commands from robot driver getting more consistently applied to the simulated actuators).