### PR TITLE
Fix indexing bug in gbp replanning

### DIFF
--- a/global_body_planner/src/global_body_planner.cpp
+++ b/global_body_planner/src/global_body_planner.cpp
@@ -168,7 +168,7 @@ void GlobalBodyPlanner::goalStateCallback(
 
 void GlobalBodyPlanner::setStartState() {
   // Reset if too far from plan
-  if (!current_plan_.isEmpty()) {
+  if (!current_plan_.isEmpty() && !publish_after_reset_delay_) {
     int current_index;
     double first_element_duration;
     quad_utils::getPlanIndex(current_plan_.getPublishedTimestamp(), dt_,


### PR DESCRIPTION
Bug in indexing caused a query to the published timestamp of the current plan before it was set. This fix prevents such a query.